### PR TITLE
Adds tags method to Giphy::Gif object that returns tags.

### DIFF
--- a/lib/giphy/gif.rb
+++ b/lib/giphy/gif.rb
@@ -12,6 +12,10 @@ module Giphy
       hash.fetch('id')
     end
 
+    def tags
+      hash.fetch('tags')
+    end
+
     def url
       URI(hash.fetch('url', ''))
     end


### PR DESCRIPTION
We add a method to be able to access the tags from a Giphy::Gif object. Previously, there was no method to access the "tags" in the hash. 
