### PR TITLE
Removing recent endpoint and adding trending

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Climate](https://codeclimate.com/github/sebasoga/giphy.png)](https://codeclimate.com/github/sebasoga/giphy)
 
 Because GIFs make life fun! Use [Giphy API](http://api.giphy.com) from your Ruby programs and
-command line. Check out [Giphy Labs](http://labs.giphy.com/) for inspiration. 
+command line. Check out [Giphy Labs](http://labs.giphy.com/) for inspiration.
 
 ![](http://media.giphy.com/media/GuDQNjS0qJHpe/200.gif)
 
@@ -39,9 +39,9 @@ to specific values the default values for the beta period will be used. Check
 
 That's it, you're ready to have fun!
 
-#### Recent
+#### Trending
 ````ruby
-Giphy.recent(tag: 'cats', limit: 5)
+Giphy.trending(limit: 5)
 ````
 
 #### Translate

--- a/lib/giphy/client.rb
+++ b/lib/giphy/client.rb
@@ -1,7 +1,7 @@
 module Giphy
   class Client
-    def recent(options={})
-      get('/recent', options)
+    def trending(options={})
+      get('/trending', options)
     end
 
     def translate(word)
@@ -15,7 +15,7 @@ module Giphy
 
     def flag(id)
       post("/#{id}/flagged")
-     end
+    end
 
     def flagged
       get('/flagged')

--- a/spec/giphy/client_spec.rb
+++ b/spec/giphy/client_spec.rb
@@ -13,13 +13,13 @@ describe Giphy::Client do
 
   subject { Giphy::Client.new }
 
-  describe "#recent" do
-    it "does a GET on the 'recent' endpoint" do
+  describe "#trending" do
+    it "does a GET on the 'trending' endpoint" do
       allow(Giphy::Request).
         to receive(:get).
-        with('/recent', options: 'options').
+        with('/trending', options: 'options').
         and_return(api_response)
-      expect(subject.recent(options: 'options')).to eq response
+      expect(subject.trending(options: 'options')).to eq response
     end
   end
 


### PR DESCRIPTION
The Giphy api changed a while ago and the recent endpoint was removed possible in favor of the trending. 

https://github.com/Giphy/GiphyAPI/commit/dffbf29243646a9ae66cbc856de84a500de65a7e