### PR TITLE
Better handling in Giphy::Response.

### DIFF
--- a/lib/giphy/errors/unexpected.rb
+++ b/lib/giphy/errors/unexpected.rb
@@ -1,0 +1,5 @@
+module Giphy
+  module Errors
+    class Unexpected < StandardError ; end
+  end
+end

--- a/lib/giphy/response.rb
+++ b/lib/giphy/response.rb
@@ -9,6 +9,7 @@ module Giphy
     end
 
     def data
+      raise Giphy::Errors::Unexpected unless response.body
       response.body['data'] || raise(Giphy::Errors::API.new(error))
     end
 

--- a/spec/giphy/response_spec.rb
+++ b/spec/giphy/response_spec.rb
@@ -36,5 +36,14 @@ describe Giphy::Response do
         expect{ subject.data }.to raise_error Giphy::Errors::API
       end
     end
+
+    context "when response is empty" do
+      let(:hash) { nil }
+
+      it "raises an error and sets its message" do
+        expect{ subject.data }.to raise_error Giphy::Errors::Unexpected
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This raises an Giphy::Errors::Unexpected exception if Giphy returns no body. Right now Giphy returns a redirect (will address that separately), but in theory it also could be just sending garbage and we want to get a better error here.

Closes #5.